### PR TITLE
Middleware group and alias options

### DIFF
--- a/config/loki.php
+++ b/config/loki.php
@@ -36,5 +36,14 @@ return [
      *  `/en/about-us` on `en` locale will be
      *  `/hr/o-nama` on `hr` locale.
      */
-    'useTranslatedUrls' => false
+    'useTranslatedUrls' => false,
+
+    /**
+     * Which middleware group is used by default.
+     *
+     * You can use null to prevent it, a string for
+     * one middleware group, or an array of strings
+     * for multiple ones.
+     */
+    'middlewareGroup' => 'web',
 ];

--- a/config/loki.php
+++ b/config/loki.php
@@ -41,9 +41,17 @@ return [
     /**
      * Which middleware group is used by default.
      *
-     * You can use null to prevent it, a string for
-     * one middleware group, or an array of strings
-     * for multiple ones.
+     * You can use a falsy value to prevent it, a
+     * string for one middleware group, or an array
+     * of strings for multiple ones.
      */
     'middlewareGroup' => 'web',
+
+    /**
+     * Which alias is used for our middleware.
+     *
+     * You can use a falsy value to prevent it,
+     * or any string.
+     */
+    'middlewareAlias' => 'loki',
 ];

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -9,6 +9,10 @@ class ServiceProvider extends LaravelServiceProvider
 {
     public function boot()
     {
+        if($middleware = $this->app['config']->get('middlewareAlias')) {
+            $this->app['router']->aliasMiddleware($middleware, Heimdall::class);
+        }
+        
         if($middlewareGroups = $this->app['config']->get('loki.middlewareGroup')) {
             foreach(array_wrap($middlewareGroups) as $group) {
                 $this->app['router']->pushMiddlewareToGroup($group, Heimdall::class);

--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -9,7 +9,11 @@ class ServiceProvider extends LaravelServiceProvider
 {
     public function boot()
     {
-        $this->app['router']->pushMiddlewareToGroup('web', Heimdall::class);
+        if($middlewareGroups = $this->app['config']->get('loki.middlewareGroup')) {
+            foreach(array_wrap($middlewareGroups) as $group) {
+                $this->app['router']->pushMiddlewareToGroup($group, Heimdall::class);
+            }
+        }
 
         $this->publishes([
             __DIR__ . '/../config/loki.php' => config_path('loki.php'),


### PR DESCRIPTION
Code is quite self explanatory.


I tend to like setting all middleware related behaviour on my own in the `Kernel`.  

This started as a way to disable the "auto add" to the `web` middleware group. I figured I can also give the ability to change the default middleware group.


Basically you can pass a falsy value , a middleware group string or an array of middleware group strings as a config option.


I also added an auto alias option, same falsy or string behaviour.