### PR TITLE
Allow PHP 7.3 as well

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require": {
-        "php": "7.2.*",
+        "php": ">=7.2",
         "illuminate/support": "5.*",
         "illuminate/http": "5.*",
         "illuminate/routing": "5.*"


### PR DESCRIPTION
The bulk edit is because of conversion from `CRLF` to `LF`.
The actual change is changing the PHP requirement to bigger than `7.2` instead of strictly `7.2`.