### PR TITLE
Use request()->segment(1) instead of route()->getPrefix()

### DIFF
--- a/src/Middleware.php
+++ b/src/Middleware.php
@@ -18,7 +18,7 @@ class Middleware
     public function handle(Request $request, Closure $next)
     {
         $route = $request->route();
-        $prefix = $route->getPrefix();
+        $prefix = $request->segment(1);
 
         // Hide default locale /en to /
         if (config('loki.hideDefaultLocale') == true and $prefix == config('loki.defaultLocale')) {

--- a/src/UrlGenerator.php
+++ b/src/UrlGenerator.php
@@ -106,7 +106,7 @@ class UrlGenerator extends LaravelUrlGenerator
             }
 
             $name = $route->getName();
-            $prefix = $route->getPrefix();
+            $prefix = request()->segment(1);
             // This is a fix for Laravel 6.
             // TODO: Maybe this is not needed anymore...
             $parameters = array_key_exists('data', $route->parameters) ? $route->parameters['data'] : $route->parameters;
@@ -131,7 +131,7 @@ class UrlGenerator extends LaravelUrlGenerator
     {
         if (is_null($path)) {
             $path = request()->path();
-            $prefix = request()->route()->getPrefix();
+            $prefix = request()->segment(1);
 
             if (!is_null($prefix)) {
                 $path = Str::replaceFirst($prefix, '', $path);


### PR DESCRIPTION
When I need to add a prefix to some routes, like 'admin', for my backoffice, the $route->getPrefix() respond 'en/admin' instead of 'en' , is more secure to use request()->segment(1)

Using Laravel 7+